### PR TITLE
use default components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
 node_js:
-  - v7
-  - v6
-  - v5
-  - v4
-  - '0.12'
+  - "6"
+  - "7"

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -4,6 +4,10 @@ var chalk = require('chalk');
 var yosay = require('yosay');
 var path = require('path');
 var mkdirp = require('mkdirp');
+const updateNotifier = require('update-notifier');
+const pkg = require('../../package.json');
+
+updateNotifier({pkg}).notify();
 
 module.exports = Generator.extend({
   prompting: function () {
@@ -26,19 +30,19 @@ module.exports = Generator.extend({
   },
 
   writing: function () {
-    this.fs.copyTpl(this.templatePath('_package.json'),  this.destinationPath(this.props.name + '/' + 'package.json'), this.props);
+    this.fs.copyTpl(this.templatePath('_package.json'), this.destinationPath(this.props.name + '/package.json'), this.props);
 
     this.fs.copy(
       this.templatePath('index.idl'),
-      this.destinationPath(this.props.name + '/' + 'index.idl')
+      this.destinationPath(this.props.name + '/index.idl')
     );
     this.fs.copy(
       this.templatePath('_index.html'),
-      this.destinationPath(this.props.name + '/' + '_index.html')
+      this.destinationPath(this.props.name + '/_index.html')
     );
     this.fs.copy(
       this.templatePath('styles.css'),
-      this.destinationPath(this.props.name + '/' + 'styles.css')
+      this.destinationPath(this.props.name + '/styles.css')
     );
     this.fs.copy(
       this.templatePath('components/'),
@@ -58,14 +62,20 @@ module.exports = Generator.extend({
     var elementDir = path.join(process.cwd(), this.props.name);
     process.chdir(elementDir);
     var self = this;
-    this.npmInstall(undefined, undefined, function() {
-      self.fs.copy(
-        self.destinationPath(self.props.name + '/node_modules/idyll-default-components/components/'),
-        self.destinationPath(self.props.name + '/components/default')
-      );
-      self.log('Your new project was created. To get started run `cd ' + self.props.name + ' && npm start`');
+    this.npmInstall(undefined, undefined, function (err) {
+      if (err) {
+        self.log(err);
+        return;
+      }
+      try {
+        self.fs.copy(
+          self.destinationPath(self.props.name + '/node_modules/idyll-default-components/components/'),
+          self.destinationPath(self.props.name + '/components/default')
+        );
+        self.log('Your new project was created. To get started run `cd ' + self.props.name + ' && npm start`');
+      } catch (e) {
+        self.log(e);
+      }
     });
-
-
   }
 });

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -48,6 +48,7 @@ module.exports = Generator.extend({
       this.templatePath('data/'),
       this.destinationPath(this.props.name + '/data')
     );
+    mkdirp.sync(this.destinationPath(this.props.name + '/components/default'));
     mkdirp.sync(this.destinationPath(this.props.name + '/build'));
     mkdirp.sync(this.destinationPath(this.props.name + '/images'));
     mkdirp.sync(this.destinationPath(this.props.name + '/fonts'));
@@ -58,6 +59,10 @@ module.exports = Generator.extend({
     process.chdir(elementDir);
     var self = this;
     this.npmInstall(undefined, undefined, function() {
+      self.fs.copy(
+        self.destinationPath(self.props.name + '/node_modules/idyll-default-components/components/'),
+        self.destinationPath(self.props.name + '/components/default')
+      );
       self.log('Your new project was created. To get started run `cd ' + self.props.name + ' && npm start`');
     });
 

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -7,7 +7,7 @@
     "deploy": "npm run build && gh-pages -d ./build"
   },
   "dependencies": {
-    "idyll": "^1.0.0",
+    "idyll": "1.0.25",
     "idyll-default-components": "^1.0.0"
   },
   "devDependencies": {

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -7,7 +7,8 @@
     "deploy": "npm run build && gh-pages -d ./build"
   },
   "dependencies": {
-    "idyll": "^1.0.0"
+    "idyll": "^1.0.0",
+    "idyll-default-components": "^1.0.0"
   },
   "devDependencies": {
     "uglify-js": "^2.7.5",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -7,7 +7,7 @@
     "deploy": "npm run build && gh-pages -d ./build"
   },
   "dependencies": {
-    "idyll": "1.0.25",
+    "idyll": "1.0.27",
     "idyll-default-components": "^1.0.0"
   },
   "devDependencies": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ var nsp = require('gulp-nsp');
 var plumber = require('gulp-plumber');
 
 gulp.task('static', function () {
-  return gulp.src('**/*.js')
+  return gulp.src(['**/*.js', '!**/components/*.js'])
     .pipe(excludeGitignore())
     .pipe(eslint())
     .pipe(eslint.format())
@@ -21,7 +21,7 @@ gulp.task('nsp', function (cb) {
 });
 
 gulp.task('pre-test', function () {
-  return gulp.src('generators/**/*.js')
+  return gulp.src(['generators/**/*.js', '!generators/**/components/*.js'])
     .pipe(excludeGitignore())
     .pipe(istanbul({
       includeUntested: true

--- a/package.json
+++ b/package.json
@@ -21,22 +21,23 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "mkdirp": "^0.5.1",
+    "update-notifier": "^2.1.0",
     "yeoman-generator": "^1.0.0",
     "yosay": "^1.2.1"
   },
   "devDependencies": {
-    "yeoman-test": "^1.6.0",
-    "yeoman-assert": "^2.2.1",
     "eslint": "^3.1.1",
     "eslint-config-xo-space": "^0.15.0",
     "gulp": "^3.9.0",
     "gulp-eslint": "^3.0.1",
     "gulp-exclude-gitignore": "^1.0.0",
-    "gulp-line-ending-corrector": "^1.0.1",
     "gulp-istanbul": "^1.0.0",
+    "gulp-line-ending-corrector": "^1.0.1",
     "gulp-mocha": "^3.0.1",
+    "gulp-nsp": "^2.1.0",
     "gulp-plumber": "^1.0.0",
-    "gulp-nsp": "^2.1.0"
+    "yeoman-assert": "^2.2.1",
+    "yeoman-test": "^1.6.0"
   },
   "eslintConfig": {
     "extends": "xo-space",

--- a/test/app.js
+++ b/test/app.js
@@ -12,9 +12,9 @@ describe('generator-idyll:app', function () {
 
   it('creates files', function () {
     assert.file([
-      '__tmp/index.idl',
-      '__tmp/styles.css',
-      '__tmp/package.json'
+      'index.idl',
+      'styles.css',
+      'package.json'
     ]);
   });
 });


### PR DESCRIPTION
This updates the generate to pull components from the [idyll-default-components](https://github.com/idyll-lang/idyll-default-components) repo, allowing them to be placed inside of user project folders and more easily customized.